### PR TITLE
Add create estimate from existing estimate

### DIFF
--- a/src/API.php
+++ b/src/API.php
@@ -107,6 +107,27 @@
 			
 			return $c->json->Details->Items;
 		}
+
+		/**
+		 * Create a new estimate from an existing one, changing the quantity
+		 *
+		 * @param int $id The ID of the existing estimate
+		 * @param int $quantity The new quantity for the new estimate
+		 * @return void
+		 * @throws InvalidRequest
+		 */
+		public function newEstimateFromExisting($id, $quantity)
+		{
+			Log::debug('Tharstern::newEstimateFromExisting()');
+
+			$url = sprintf("%s/estimates/newestimatefromexisting?id=%s&quantity=%s", $this->url, $id, $quantity);
+
+			try {
+				$c = new CURL($url, method: CURL::GET, headers: $this->headers);
+			} catch (\ThriveData\ThrivePHP\BadRequest $e) {
+				throw new InvalidRequest($e->getMessage(), previous: $e, context: $e->getContext());
+			}
+		}
 		
 		public function estrequest($json)
 		{


### PR DESCRIPTION
There is an end point to create an estimate
from an existing estimate. I needed to add this
end point to the API class so that I could
have this functionality in my project.

The need arose from a requirement to quickly
display an estimated cost for a product and some
products only have the option to use an
existing estimate as a template.