### PR TITLE
Ommited return in function newEstimateFromExisting

### DIFF
--- a/src/API.php
+++ b/src/API.php
@@ -153,7 +153,7 @@
 				throw new InvalidRequest($e->getMessage(), previous: $e, context: $e->getContext());
 			}
 
-			return $c->json->Details;
+			return $c->json->Details->Estimate;
 		}
 		
 		public function estrequest($json)

--- a/src/API.php
+++ b/src/API.php
@@ -138,7 +138,7 @@
 		 *
 		 * @param int $id The ID of the existing estimate
 		 * @param int $quantity The new quantity for the new estimate
-		 * @return void
+		 * @return object The details of the newly created estimate
 		 * @throws InvalidRequest
 		 */
 		public function newEstimateFromExisting($id, $quantity)
@@ -152,6 +152,8 @@
 			} catch (\ThriveData\ThrivePHP\BadRequest $e) {
 				throw new InvalidRequest($e->getMessage(), previous: $e, context: $e->getContext());
 			}
+
+			return $c->json->Details;
 		}
 		
 		public function estrequest($json)


### PR DESCRIPTION
previous commits didn't have a return statement
but the function is expected to return an object
adding a return statement to return the details
of the newly created estimate.