### PR TITLE
Estimate from existing estimate bug fix

### DIFF
--- a/src/API.php
+++ b/src/API.php
@@ -145,7 +145,7 @@
 		{
 			Log::debug('Tharstern::newEstimateFromExisting()');
 
-			$url = sprintf("%s/estimates/newestimatefromexisting?id=%s&quantity=%s", $this->url, $id, $quantity);
+			$url = sprintf("%s/estimate/newestimatefromexisting?estimateId=%s&quantity=%s", $this->url, $id, $quantity);
 
 			try {
 				$c = new CURL($url, method: CURL::POST, headers: $this->headers);


### PR DESCRIPTION
This commit fixes an erroneous url for the
endpoint for creating an estimate from an existing estimate.